### PR TITLE
Adapt contest layout and meta colors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import { AttemptReview } from './pages/AttemptReview'
 function App() {
   return (
     <Router>
-      <div className="min-h-screen bg-hackerrank-dark">
+      <div className="min-h-screen bg-meta-dark">
         <Navigation />
         <main>
           <Routes>

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -46,13 +46,13 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
     <div className="code-editor-container h-full flex flex-col">
       <div className="code-editor-header">
         <div className="flex items-center space-x-3">
-          <span className="text-sm font-semibold text-hackerrank-text">{languageConfig.name}</span>
-          <span className="text-xs text-hackerrank-textSecondary font-medium bg-hackerrank-light px-2 py-1 rounded-md">
+          <span className="text-sm font-semibold text-meta-text">{languageConfig.name}</span>
+          <span className="text-xs text-meta-textSecondary font-medium bg-meta-light px-2 py-1 rounded-md">
             {languageConfig.extension}
           </span>
         </div>
         {readOnly && (
-          <div className="text-xs text-hackerrank-textSecondary font-medium bg-hackerrank-light px-2 py-1 rounded-md">
+          <div className="text-xs text-meta-textSecondary font-medium bg-meta-light px-2 py-1 rounded-md">
             Read Only
           </div>
         )}
@@ -68,7 +68,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           style={{ 
             height: height === '100%' ? '100%' : height,
             minHeight: height === '100%' ? '400px' : height,
-            backgroundColor: readOnly ? '#1a1f2e' : '#0f1419',
+            backgroundColor: readOnly ? '#1e293b' : '#0f172a',
             resize: 'none',
           }}
           placeholder={readOnly ? '' : `Write your ${languageConfig.name} code here...`}
@@ -79,7 +79,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         />
         
         {/* Line numbers overlay */}
-        <div className="absolute left-0 top-0 p-4 pointer-events-none select-none text-hackerrank-textSecondary text-sm font-mono leading-relaxed">
+        <div className="absolute left-0 top-0 p-4 pointer-events-none select-none text-meta-textSecondary text-sm font-mono leading-relaxed">
           {value.split('\n').map((_, index) => (
             <div key={index} className="text-right pr-3" style={{ minWidth: '2.5em' }}>
               {index + 1}

--- a/frontend/src/components/ContestCard.tsx
+++ b/frontend/src/components/ContestCard.tsx
@@ -10,25 +10,25 @@ interface ContestCardProps {
 export const ContestCard = ({ contest }: ContestCardProps) => {
   const getStatusIcon = () => {
     if (!contest.has_attempts) {
-      return <PlayCircle className="w-5 h-5 text-hackerrank-textSecondary" />
+      return <PlayCircle className="w-5 h-5 text-meta-textSecondary" />
     }
     
     switch (contest.last_attempt_status) {
       case 'completed':
-        return <CheckCircle className="w-5 h-5 text-hackerrank-success" />
+        return <CheckCircle className="w-5 h-5 text-meta-success" />
       case 'in_progress':
-        return <Clock className="w-5 h-5 text-hackerrank-success" />
+        return <Clock className="w-5 h-5 text-meta-success" />
       case 'abandoned':
-        return <RotateCcw className="w-5 h-5 text-hackerrank-textSecondary" />
+        return <RotateCcw className="w-5 h-5 text-meta-textSecondary" />
       default:
-        return <PlayCircle className="w-5 h-5 text-hackerrank-textSecondary" />
+        return <PlayCircle className="w-5 h-5 text-meta-textSecondary" />
     }
   }
 
   const getStatusBadge = () => {
     if (!contest.has_attempts) {
       return (
-        <span className="px-3 py-1 rounded-full text-xs font-semibold border text-hackerrank-textSecondary bg-hackerrank-light border-hackerrank-border">
+        <span className="px-3 py-1 rounded-full text-xs font-semibold border text-meta-textSecondary bg-meta-light border-meta-border">
           Not Attempted
         </span>
       )
@@ -45,15 +45,15 @@ export const ContestCard = ({ contest }: ContestCardProps) => {
   }
 
   return (
-    <div className="card hackerrank-card-hover gradient-card">
+    <div className="card meta-card-hover gradient-card">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-xl font-bold text-hackerrank-text">{contest.name}</h3>
+        <h3 className="text-xl font-bold text-meta-text">{contest.name}</h3>
         {getStatusIcon()}
       </div>
       
       <div className="flex items-center justify-between mb-6">
         {getStatusBadge()}
-        <span className="text-sm text-hackerrank-textSecondary font-medium">3 Questions • 1 Hour</span>
+        <span className="text-sm text-meta-textSecondary font-medium">3 Questions • 1 Hour</span>
       </div>
       
       <div className="flex space-x-3">

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -17,12 +17,12 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
 }) => {
   return (
     <div className="flex items-center space-x-2">
-      <span className="text-sm text-hackerrank-textSecondary font-medium">Language:</span>
+      <span className="text-sm text-meta-textSecondary font-medium">Language:</span>
       <select
         value={selectedLanguage}
         onChange={(e) => onChange(e.target.value as Language)}
         disabled={disabled}
-        className="text-sm border border-hackerrank-border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-hackerrank-green focus:border-transparent bg-hackerrank-light text-hackerrank-text font-medium shadow-hackerrank transition-all duration-200 hover:border-hackerrank-borderLight"
+        className="text-sm border border-meta-border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-meta-blue focus:border-transparent bg-meta-light text-meta-text font-medium shadow-meta transition-all duration-200 hover:border-meta-borderLight"
       >
         {languages.map((language) => {
           const config = getLanguageConfig(language)

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -11,19 +11,19 @@ export const Navigation: React.FC = () => {
   }
 
   return (
-    <nav className="bg-hackerrank-darker/80 backdrop-blur-md border-b border-hackerrank-border sticky top-0 z-50">
+    <nav className="bg-meta-darker/80 backdrop-blur-md border-b border-meta-border sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center space-x-8">
             <Link 
               to="/" 
-              className="flex items-center space-x-3 text-lg font-bold text-hackerrank-text hover:text-hackerrank-green transition-all duration-200 group"
+              className="flex items-center space-x-3 text-lg font-bold text-meta-text hover:text-meta-blue transition-all duration-200 group"
             >
-              <div className="w-10 h-10 hackerrank-gradient rounded-xl flex items-center justify-center text-hackerrank-dark text-lg font-bold shadow-hackerrank group-hover:shadow-hackerrank-lg transition-all duration-200">
-                HR
+              <div className="w-10 h-10 meta-gradient rounded-xl flex items-center justify-center text-meta-dark text-lg font-bold shadow-meta group-hover:shadow-meta-lg transition-all duration-200">
+                C
               </div>
-              <span className="text-xl font-extrabold bg-gradient-to-r from-hackerrank-green to-hackerrank-greenLight bg-clip-text text-transparent">
-                HackerRank
+              <span className="text-xl font-extrabold bg-gradient-to-r from-meta-blue to-meta-blueLight bg-clip-text text-transparent">
+                CodeContest
               </span>
             </Link>
             
@@ -53,9 +53,9 @@ export const Navigation: React.FC = () => {
           </div>
 
           <div className="flex items-center space-x-4">
-            <div className="hidden sm:flex items-center space-x-3 text-sm text-hackerrank-textSecondary">
+            <div className="hidden sm:flex items-center space-x-3 text-sm text-meta-textSecondary">
               <span className="font-medium">Ready to code?</span>
-              <div className="w-2 h-2 bg-hackerrank-green rounded-full animate-pulse-slow"></div>
+              <div className="w-2 h-2 bg-meta-blue rounded-full animate-pulse-slow"></div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/QuestionCard.tsx
+++ b/frontend/src/components/QuestionCard.tsx
@@ -23,44 +23,44 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({
   
   return (
     <div 
-      className={`card cursor-pointer transition-all duration-300 hover:shadow-hackerrank-lg ${
-        isActive ? 'ring-2 ring-hackerrank-green border-hackerrank-green shadow-hackerrank-lg' : 'hackerrank-card-hover gradient-card'
+      className={`card cursor-pointer transition-all duration-300 hover:shadow-meta-lg ${
+        isActive ? 'ring-2 ring-meta-blue border-meta-blue shadow-meta-lg' : 'meta-card-hover gradient-card'
       }`}
       onClick={onClick}
     >
       <div className="flex items-start justify-between">
         <div className="flex-1">
           <div className="flex items-center space-x-3 mb-3">
-            <span className="bg-hackerrank-darker text-hackerrank-text px-3 py-1.5 rounded-lg text-sm font-semibold">
+            <span className="bg-meta-darker text-meta-text px-3 py-1.5 rounded-lg text-sm font-semibold">
               Question {questionNumber}
             </span>
             <span className={`px-3 py-1.5 rounded-lg text-xs font-semibold border ${difficultyColors[question.difficulty]}`}>
               {question.difficulty}
             </span>
             {hasCode && (
-              <span className="bg-hackerrank-success text-hackerrank-dark px-3 py-1.5 rounded-lg text-xs font-semibold border border-hackerrank-success">
+              <span className="bg-meta-success text-meta-dark px-3 py-1.5 rounded-lg text-xs font-semibold border border-meta-success">
                 Code Written
               </span>
             )}
           </div>
           
-          <h3 className="text-xl font-bold text-hackerrank-text mb-3">
+          <h3 className="text-xl font-bold text-meta-text mb-3">
             {question.title}
           </h3>
           
-          <p className="text-hackerrank-textSecondary text-sm mb-4 line-clamp-3 leading-relaxed">
+          <p className="text-meta-textSecondary text-sm mb-4 line-clamp-3 leading-relaxed">
             {question.description}
           </p>
           
-          <div className="flex items-center justify-between text-xs text-hackerrank-textSecondary">
+          <div className="flex items-center justify-between text-xs text-meta-textSecondary">
             <span className="font-medium">{question.category}</span>
             <span className="font-mono">#{question.neetcode_number}</span>
           </div>
           
           {userLanguage && (
             <div className="mt-3">
-              <span className="text-xs text-hackerrank-textSecondary font-medium">
-                Language: <span className="font-semibold text-hackerrank-text">{userLanguage}</span>
+              <span className="text-xs text-meta-textSecondary font-medium">
+                Language: <span className="font-semibold text-meta-text">{userLanguage}</span>
               </span>
             </div>
           )}

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -82,10 +82,10 @@ export const Timer: React.FC<TimerProps> = ({
   const progressPercentage = (timerState.timeLeft / initialTime) * 100
 
   return (
-    <div className="bg-hackerrank-light/50 backdrop-blur-sm border border-hackerrank-border rounded-xl p-4 shadow-hackerrank">
+    <div className="bg-meta-light/50 backdrop-blur-sm border border-meta-border rounded-xl p-4 shadow-meta">
       {/* Notification */}
       {notification && (
-        <div className="px-4 py-3 bg-hackerrank-warning/20 border border-hackerrank-warning/30 rounded-lg text-hackerrank-warning text-sm font-medium mb-4">
+        <div className="px-4 py-3 bg-meta-warning/20 border border-meta-warning/30 rounded-lg text-meta-warning text-sm font-medium mb-4">
           {notification}
         </div>
       )}
@@ -96,28 +96,28 @@ export const Timer: React.FC<TimerProps> = ({
             <div className={`text-3xl font-mono font-bold ${timerColorClass}`}>
               {formatTime(timerState.timeLeft)}
             </div>
-            <div className="text-sm text-hackerrank-textSecondary font-medium">
+            <div className="text-sm text-meta-textSecondary font-medium">
               {timerState.timeLeft <= 0 ? 'Time\'s up!' : 'remaining'}
             </div>
           </div>
           
           {/* Progress indicator */}
           <div className="flex items-center space-x-3">
-            <div className="w-40 bg-hackerrank-border rounded-full h-3 overflow-hidden">
+            <div className="w-40 bg-meta-border rounded-full h-3 overflow-hidden">
               <div
                 className={`h-3 rounded-full transition-all duration-1000 ${
                   timerState.timeLeft <= 300 
-                    ? 'bg-hackerrank-error' 
+                    ? 'bg-meta-error' 
                     : timerState.timeLeft <= 1800 
-                    ? 'bg-hackerrank-warning' 
-                    : 'bg-hackerrank-success'
+                    ? 'bg-meta-warning' 
+                    : 'bg-meta-success'
                 }`}
                 style={{
                   width: `${progressPercentage}%`
                 }}
               />
             </div>
-            <span className="text-sm text-hackerrank-textSecondary font-medium min-w-0">
+            <span className="text-sm text-meta-textSecondary font-medium min-w-0">
               {Math.round(progressPercentage)}%
             </span>
           </div>
@@ -127,14 +127,14 @@ export const Timer: React.FC<TimerProps> = ({
           <button
             onClick={toggleTimer}
             disabled={timerState.timeLeft <= 0}
-            className="btn btn-secondary btn-sm shadow-hackerrank"
+            className="btn btn-secondary btn-sm shadow-meta"
           >
             {timerState.isRunning ? 'Pause' : 'Resume'}
           </button>
           
           <button
             onClick={resetTimer}
-            className="btn btn-secondary btn-sm shadow-hackerrank"
+            className="btn btn-secondary btn-sm shadow-meta"
           >
             Reset
           </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,8 +8,8 @@
   }
   
   body {
-    @apply bg-hackerrank-dark text-hackerrank-text antialiased;
-    background: linear-gradient(135deg, #0f1419 0%, #1a1f2e 100%);
+    @apply bg-meta-dark text-meta-text antialiased;
+    background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
   }
   
   code, pre {
@@ -23,19 +23,19 @@
   }
   
   .btn-primary {
-    @apply bg-hackerrank-green text-hackerrank-dark hover:bg-hackerrank-greenDark focus:ring-hackerrank-green shadow-hackerrank;
+    @apply bg-meta-blue text-meta-dark hover:bg-meta-blueDark focus:ring-meta-blue shadow-meta;
   }
   
   .btn-secondary {
-    @apply bg-hackerrank-light text-hackerrank-text border-hackerrank-border hover:bg-hackerrank-lighter focus:ring-hackerrank-green shadow-hackerrank;
+    @apply bg-meta-light text-meta-text border-meta-border hover:bg-meta-lighter focus:ring-meta-blue shadow-meta;
   }
   
   .btn-success {
-    @apply bg-hackerrank-success text-hackerrank-dark hover:bg-hackerrank-greenDark focus:ring-hackerrank-success font-semibold shadow-hackerrank;
+    @apply bg-meta-success text-meta-dark hover:bg-meta-success/90 focus:ring-meta-success font-semibold shadow-meta;
   }
   
   .btn-danger {
-    @apply bg-hackerrank-error text-white hover:bg-red-600 focus:ring-hackerrank-error shadow-hackerrank;
+    @apply bg-meta-error text-white hover:bg-meta-error/90 focus:ring-meta-error shadow-meta;
   }
   
   .btn-sm {
@@ -51,35 +51,35 @@
   }
   
   .badge-success {
-    @apply bg-hackerrank-success text-hackerrank-dark font-semibold;
+    @apply bg-meta-success text-meta-dark font-semibold;
   }
   
   .badge-warning {
-    @apply bg-hackerrank-warning text-hackerrank-dark font-semibold;
+    @apply bg-meta-warning text-meta-dark font-semibold;
   }
   
   .badge-danger {
-    @apply bg-hackerrank-error text-white font-semibold;
+    @apply bg-meta-error text-white font-semibold;
   }
   
   .badge-info {
-    @apply bg-hackerrank-info text-white font-semibold;
+    @apply bg-meta-info text-white font-semibold;
   }
   
   .badge-secondary {
-    @apply bg-hackerrank-light text-hackerrank-text border border-hackerrank-border;
+    @apply bg-meta-light text-meta-text border border-meta-border;
   }
   
   .difficulty-easy {
-    @apply text-hackerrank-success bg-hackerrank-success/10 border-hackerrank-success/20;
+    @apply text-meta-success bg-meta-success/10 border-meta-success/20;
   }
   
   .difficulty-medium {
-    @apply text-hackerrank-warning bg-hackerrank-warning/10 border-hackerrank-warning/20;
+    @apply text-meta-warning bg-meta-warning/10 border-meta-warning/20;
   }
   
   .difficulty-hard {
-    @apply text-hackerrank-error bg-hackerrank-error/10 border-hackerrank-error/20;
+    @apply text-meta-error bg-meta-error/10 border-meta-error/20;
   }
   
   .status-indicator {
@@ -87,19 +87,19 @@
   }
   
   .status-completed {
-    @apply bg-hackerrank-success;
+    @apply bg-meta-success;
   }
   
   .status-attempted {
-    @apply bg-hackerrank-warning;
+    @apply bg-meta-warning;
   }
   
   .status-not-attempted {
-    @apply bg-hackerrank-border;
+    @apply bg-meta-border;
   }
 
   .card {
-    @apply bg-hackerrank-light border border-hackerrank-border rounded-xl p-6 shadow-hackerrank backdrop-blur-sm;
+    @apply bg-meta-light border border-meta-border rounded-xl p-6 shadow-meta backdrop-blur-sm;
   }
 
   .nav-link {
@@ -107,25 +107,25 @@
   }
 
   .nav-link-active {
-    @apply text-hackerrank-green bg-hackerrank-green/10 border border-hackerrank-green/20;
+    @apply text-meta-blue bg-meta-blue/10 border border-meta-blue/20;
   }
 
   .nav-link-inactive {
-    @apply text-hackerrank-textSecondary hover:text-hackerrank-text hover:bg-hackerrank-lighter;
+    @apply text-meta-textSecondary hover:text-meta-text hover:bg-meta-lighter;
   }
 }
 
 /* Code editor styles */
 .code-editor-container {
-  @apply border border-hackerrank-border rounded-xl overflow-hidden bg-hackerrank-darker shadow-hackerrank;
+  @apply border border-meta-border rounded-xl overflow-hidden bg-meta-darker shadow-meta;
 }
 
 .code-editor-header {
-  @apply bg-hackerrank-light border-b border-hackerrank-border px-4 py-3 flex items-center justify-between;
+  @apply bg-meta-light border-b border-meta-border px-4 py-3 flex items-center justify-between;
 }
 
 .code-editor-textarea {
-  @apply w-full p-4 font-mono text-sm resize-none focus:outline-none border-none bg-hackerrank-darker text-hackerrank-text;
+  @apply w-full p-4 font-mono text-sm resize-none focus:outline-none border-none bg-meta-darker text-meta-text;
   font-family: 'JetBrains Mono', 'Fira Code', 'Source Code Pro', 'Consolas', monospace;
   line-height: 1.6;
   tab-size: 2;
@@ -165,16 +165,16 @@
 }
 
 ::-webkit-scrollbar-track {
-  background: #1a1f2e;
+  background: #1e293b;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #4a5568;
+  background: #475569;
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #718096;
+  background: #64748b;
 }
 
 /* Utility classes */
@@ -185,32 +185,32 @@
   overflow: hidden;
 }
 
-/* HackerRank specific styles */
-.hackerrank-gradient {
-  background: linear-gradient(135deg, #00ea64 0%, #00c853 100%);
+/* Meta specific styles */
+.meta-gradient {
+  background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%);
 }
 
-.hackerrank-shadow {
+.meta-shadow {
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
 }
 
-.hackerrank-card-hover {
-  @apply transition-all duration-300 hover:shadow-hackerrank-lg hover:border-hackerrank-green/30 hover:transform hover:-translate-y-1;
+.meta-card-hover {
+  @apply transition-all duration-300 hover:shadow-meta-lg hover:border-meta-blue/30 hover:transform hover:-translate-y-1;
 }
 
 /* Modern glass effect */
 .glass {
-  background: rgba(26, 31, 46, 0.8);
+  background: rgba(30, 41, 59, 0.8);
   backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 /* Gradient backgrounds */
 .gradient-bg {
-  background: linear-gradient(135deg, #0f1419 0%, #1a1f2e 100%);
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
 }
 
 .gradient-card {
-  background: linear-gradient(135deg, rgba(26, 31, 46, 0.9) 0%, rgba(42, 47, 62, 0.9) 100%);
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.9) 0%, rgba(51, 65, 85, 0.9) 100%);
   backdrop-filter: blur(10px);
 }

--- a/frontend/src/pages/AttemptHistory.tsx
+++ b/frontend/src/pages/AttemptHistory.tsx
@@ -52,10 +52,10 @@ export const AttemptHistory: React.FC = () => {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="animate-pulse">
-          <div className="h-8 bg-hackerrank-light rounded-xl w-1/4 mb-6"></div>
+          <div className="h-8 bg-meta-light rounded-xl w-1/4 mb-6"></div>
           <div className="space-y-4">
             {[...Array(5)].map((_, i) => (
-              <div key={i} className="h-20 bg-hackerrank-light rounded-xl"></div>
+              <div key={i} className="h-20 bg-meta-light rounded-xl"></div>
             ))}
           </div>
         </div>
@@ -67,55 +67,55 @@ export const AttemptHistory: React.FC = () => {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-4xl font-bold text-hackerrank-text mb-3 bg-gradient-to-r from-hackerrank-text to-hackerrank-textSecondary bg-clip-text text-transparent">
+        <h1 className="text-4xl font-bold text-meta-text mb-3 bg-gradient-to-r from-meta-text to-meta-textSecondary bg-clip-text text-transparent">
           Submissions
         </h1>
-        <p className="text-hackerrank-textSecondary text-lg">
+        <p className="text-meta-textSecondary text-lg">
           Track your progress across all contest attempts
         </p>
       </div>
 
       {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-        <div className="card hackerrank-card-hover gradient-card">
+        <div className="card meta-card-hover gradient-card">
           <div className="flex items-center">
             <div className="flex-1">
-              <p className="text-sm font-medium text-hackerrank-textSecondary">Total</p>
-              <p className="text-3xl font-bold text-hackerrank-text">{stats.total}</p>
+              <p className="text-sm font-medium text-meta-textSecondary">Total</p>
+              <p className="text-3xl font-bold text-meta-text">{stats.total}</p>
             </div>
           </div>
         </div>
 
-        <div className="card hackerrank-card-hover gradient-card">
+        <div className="card meta-card-hover gradient-card">
           <div className="flex items-center">
             <div className="flex-1">
-              <p className="text-sm font-medium text-hackerrank-textSecondary">Completed</p>
-              <p className="text-3xl font-bold text-hackerrank-success">{stats.completed}</p>
+              <p className="text-sm font-medium text-meta-textSecondary">Completed</p>
+              <p className="text-3xl font-bold text-meta-success">{stats.completed}</p>
             </div>
           </div>
         </div>
 
-        <div className="card hackerrank-card-hover gradient-card">
+        <div className="card meta-card-hover gradient-card">
           <div className="flex items-center">
             <div className="flex-1">
-              <p className="text-sm font-medium text-hackerrank-textSecondary">In Progress</p>
-              <p className="text-3xl font-bold text-hackerrank-warning">{stats.inProgress}</p>
+              <p className="text-sm font-medium text-meta-textSecondary">In Progress</p>
+              <p className="text-3xl font-bold text-meta-warning">{stats.inProgress}</p>
             </div>
           </div>
         </div>
 
-        <div className="card hackerrank-card-hover gradient-card">
+        <div className="card meta-card-hover gradient-card">
           <div className="flex items-center">
             <div className="flex-1">
-              <p className="text-sm font-medium text-hackerrank-textSecondary">Abandoned</p>
-              <p className="text-3xl font-bold text-hackerrank-textSecondary">{stats.abandoned}</p>
+              <p className="text-sm font-medium text-meta-textSecondary">Abandoned</p>
+              <p className="text-3xl font-bold text-meta-textSecondary">{stats.abandoned}</p>
             </div>
           </div>
         </div>
       </div>
 
       {/* Filter Tabs */}
-      <div className="border-b border-hackerrank-border mb-6">
+      <div className="border-b border-meta-border mb-6">
         <nav className="-mb-px flex space-x-8">
           {(['all', 'completed', 'in_progress', 'abandoned'] as const).map((status) => (
             <button
@@ -123,8 +123,8 @@ export const AttemptHistory: React.FC = () => {
               onClick={() => setFilter(status)}
               className={`py-3 px-1 border-b-2 font-semibold text-sm transition-all duration-200 ${
                 filter === status
-                  ? 'border-hackerrank-green text-hackerrank-green'
-                  : 'border-transparent text-hackerrank-textSecondary hover:text-hackerrank-text hover:border-hackerrank-border'
+                  ? 'border-meta-blue text-meta-blue'
+                  : 'border-transparent text-meta-textSecondary hover:text-meta-text hover:border-meta-border'
               }`}
             >
               {status === 'all' ? 'All' : getStatusText(status)} ({
@@ -142,28 +142,28 @@ export const AttemptHistory: React.FC = () => {
       <div className="card p-0 overflow-hidden gradient-card">
         {filteredAttempts.length === 0 ? (
           <div className="px-6 py-12 text-center">
-            <div className="text-hackerrank-textSecondary mb-2 text-lg font-medium">No submissions found</div>
-            <p className="text-sm text-hackerrank-textSecondary mb-4">
+            <div className="text-meta-textSecondary mb-2 text-lg font-medium">No submissions found</div>
+            <p className="text-sm text-meta-textSecondary mb-4">
               {filter === 'all' 
                 ? "You haven't made any submissions yet."
                 : `No ${getStatusText(filter).toLowerCase()} submissions found.`}
             </p>
             {filter === 'all' && (
-              <Link to="/" className="btn btn-primary shadow-hackerrank">
+              <Link to="/" className="btn btn-primary shadow-meta">
                 Start Your First Contest
               </Link>
             )}
           </div>
         ) : (
-          <div className="divide-y divide-hackerrank-border">
+          <div className="divide-y divide-meta-border">
             {filteredAttempts.map((attempt) => (
-              <div key={attempt.id} className="px-6 py-4 hover:bg-hackerrank-darker/30 transition-all duration-200">
+              <div key={attempt.id} className="px-6 py-4 hover:bg-meta-darker/30 transition-all duration-200">
                 <div className="flex items-center justify-between">
                   <div className="flex-1">
                     <div className="flex items-center space-x-4 mb-3">
                       <Link 
                         to={`/contest/${attempt.contest_id}`}
-                        className="text-hackerrank-green hover:text-hackerrank-greenLight font-semibold text-lg transition-colors"
+                        className="text-meta-blue hover:text-meta-blueLight font-semibold text-lg transition-colors"
                       >
                         {attempt.contest?.name || `Contest ${attempt.contest_id}`}
                       </Link>
@@ -173,28 +173,28 @@ export const AttemptHistory: React.FC = () => {
                       </span>
                     </div>
                     
-                    <div className="grid grid-cols-1 md:grid-cols-4 gap-4 text-sm text-hackerrank-textSecondary">
+                    <div className="grid grid-cols-1 md:grid-cols-4 gap-4 text-sm text-meta-textSecondary">
                       <div>
-                        <span className="text-hackerrank-textSecondary font-medium">Started:</span>
-                        <div className="font-semibold text-hackerrank-text">
+                        <span className="text-meta-textSecondary font-medium">Started:</span>
+                        <div className="font-semibold text-meta-text">
                           {new Date(attempt.started_at).toLocaleDateString()}
                         </div>
-                        <div className="text-xs text-hackerrank-textSecondary">
+                        <div className="text-xs text-meta-textSecondary">
                           {new Date(attempt.started_at).toLocaleTimeString()}
                         </div>
                       </div>
                       
                       {attempt.completed_at && (
                         <div>
-                          <span className="text-hackerrank-textSecondary font-medium">Duration:</span>
-                          <div className="font-semibold text-hackerrank-text">
+                          <span className="text-meta-textSecondary font-medium">Duration:</span>
+                          <div className="font-semibold text-meta-text">
                             {formatTime(attempt.duration_seconds || 0)}
                           </div>
                         </div>
                       )}
                       
                       <div>
-                        <span className="text-hackerrank-textSecondary font-medium">Languages:</span>
+                        <span className="text-meta-textSecondary font-medium">Languages:</span>
                         <div className="flex flex-wrap gap-1 mt-1">
                           {[attempt.question1_language, attempt.question2_language, attempt.question3_language]
                             .filter(Boolean)
@@ -205,21 +205,21 @@ export const AttemptHistory: React.FC = () => {
                             ))}
                           {![attempt.question1_language, attempt.question2_language, attempt.question3_language]
                             .some(Boolean) && (
-                            <span className="text-hackerrank-textSecondary text-xs">None</span>
+                            <span className="text-meta-textSecondary text-xs">None</span>
                           )}
                         </div>
                       </div>
                       
                       <div>
-                        <span className="text-hackerrank-textSecondary font-medium">Problems:</span>
+                        <span className="text-meta-textSecondary font-medium">Problems:</span>
                         <div className="flex space-x-1 mt-1">
                           {[1, 2, 3].map(i => (
                             <div
                               key={i}
                               className={`w-3 h-3 rounded-full ${
                                 attempt[`question${i}_code` as keyof Attempt]
-                                  ? 'bg-hackerrank-success'
-                                  : 'bg-hackerrank-border'
+                                  ? 'bg-meta-success'
+                                  : 'bg-meta-border'
                               }`}
                             />
                           ))}
@@ -232,14 +232,14 @@ export const AttemptHistory: React.FC = () => {
                     {attempt.status === 'in_progress' ? (
                       <Link
                         to={`/contest/${attempt.contest_id}/attempt/${attempt.id}`}
-                        className="btn btn-primary btn-sm shadow-hackerrank"
+                        className="btn btn-primary btn-sm shadow-meta"
                       >
                         Resume
                       </Link>
                     ) : (
                       <Link
                         to={`/attempt/${attempt.id}/review`}
-                        className="btn btn-secondary btn-sm shadow-hackerrank"
+                        className="btn btn-secondary btn-sm shadow-meta"
                       >
                         Review
                       </Link>
@@ -247,7 +247,7 @@ export const AttemptHistory: React.FC = () => {
                     
                     <button
                       onClick={() => handleDeleteAttempt(attempt.id)}
-                      className="btn btn-danger btn-sm shadow-hackerrank"
+                      className="btn btn-danger btn-sm shadow-meta"
                     >
                       Delete
                     </button>

--- a/frontend/src/pages/AttemptReview.tsx
+++ b/frontend/src/pages/AttemptReview.tsx
@@ -34,10 +34,10 @@ export const AttemptReview: React.FC = () => {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="animate-pulse">
-          <div className="h-8 bg-hackerrank-light rounded w-1/3 mb-6"></div>
+          <div className="h-8 bg-meta-light rounded w-1/3 mb-6"></div>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <div className="h-96 bg-hackerrank-light rounded"></div>
-            <div className="h-96 bg-hackerrank-light rounded"></div>
+            <div className="h-96 bg-meta-light rounded"></div>
+            <div className="h-96 bg-meta-light rounded"></div>
           </div>
         </div>
       </div>
@@ -48,7 +48,7 @@ export const AttemptReview: React.FC = () => {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-hackerrank-text mb-4">Submission not found</h1>
+          <h1 className="text-2xl font-bold text-meta-text mb-4">Submission not found</h1>
           <Link to="/history" className="btn btn-primary">Back to Submissions</Link>
         </div>
       </div>
@@ -93,16 +93,16 @@ export const AttemptReview: React.FC = () => {
       <nav className="flex mb-6" aria-label="Breadcrumb">
         <ol className="flex items-center space-x-4">
           <li>
-            <Link to="/history" className="text-hackerrank-textSecondary hover:text-hackerrank-text">
+            <Link to="/history" className="text-meta-textSecondary hover:text-meta-text">
               Submissions
             </Link>
           </li>
           <li>
             <div className="flex items-center">
-              <svg className="flex-shrink-0 h-5 w-5 text-hackerrank-border" fill="currentColor" viewBox="0 0 20 20">
+              <svg className="flex-shrink-0 h-5 w-5 text-meta-border" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
               </svg>
-              <span className="ml-4 text-sm font-medium text-hackerrank-text">
+              <span className="ml-4 text-sm font-medium text-meta-text">
                 {attempt.contest?.name || 'Review'}
               </span>
             </div>
@@ -114,10 +114,10 @@ export const AttemptReview: React.FC = () => {
       <div className="mb-8">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-hackerrank-text mb-2">
+            <h1 className="text-3xl font-bold text-meta-text mb-2">
               Submission Review
             </h1>
-            <p className="text-hackerrank-textSecondary">
+            <p className="text-meta-textSecondary">
               {attempt.contest?.name} • Problem {activeQuestion} of 3
             </p>
           </div>
@@ -126,41 +126,41 @@ export const AttemptReview: React.FC = () => {
 
       {/* Submission Info */}
       <div className="card mb-8">
-        <h2 className="text-lg font-semibold text-hackerrank-text mb-4">Submission Details</h2>
+        <h2 className="text-lg font-semibold text-meta-text mb-4">Submission Details</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <div>
-            <h3 className="text-sm font-medium text-hackerrank-textSecondary mb-2">Status</h3>
+            <h3 className="text-sm font-medium text-meta-textSecondary mb-2">Status</h3>
             <span className={`badge ${statusColors[attempt.status]} border`}>
               {getStatusText(attempt.status)}
             </span>
           </div>
           
           <div>
-            <h3 className="text-sm font-medium text-hackerrank-textSecondary mb-2">Started</h3>
-            <div className="text-sm text-hackerrank-text">
+            <h3 className="text-sm font-medium text-meta-textSecondary mb-2">Started</h3>
+            <div className="text-sm text-meta-text">
               {new Date(attempt.started_at).toLocaleString()}
             </div>
           </div>
           
           {attempt.completed_at && (
             <div>
-              <h3 className="text-sm font-medium text-hackerrank-textSecondary mb-2">Duration</h3>
-              <div className="text-sm text-hackerrank-text">
+              <h3 className="text-sm font-medium text-meta-textSecondary mb-2">Duration</h3>
+              <div className="text-sm text-meta-text">
                 {formatTime(attempt.duration_seconds || 0)}
               </div>
             </div>
           )}
           
           <div>
-            <h3 className="text-sm font-medium text-hackerrank-textSecondary mb-2">Problems Attempted</h3>
+            <h3 className="text-sm font-medium text-meta-textSecondary mb-2">Problems Attempted</h3>
             <div className="flex space-x-1">
               {[1, 2, 3].map(i => (
                 <div
                   key={i}
                   className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium ${
                     attempt[`question${i}_code` as keyof Attempt]
-                      ? 'bg-hackerrank-green text-hackerrank-dark'
-                      : 'bg-hackerrank-light text-hackerrank-textSecondary'
+                      ? 'bg-meta-success text-meta-dark'
+                      : 'bg-meta-light text-meta-textSecondary'
                   }`}
                 >
                   {i}
@@ -173,7 +173,7 @@ export const AttemptReview: React.FC = () => {
 
       {/* Problem Navigation */}
       <div className="mb-6">
-        <div className="border-b border-hackerrank-border">
+        <div className="border-b border-meta-border">
           <nav className="-mb-px flex space-x-8">
             {questions.map((question, index) => (
               <button
@@ -181,14 +181,14 @@ export const AttemptReview: React.FC = () => {
                 onClick={() => setActiveQuestion(index + 1)}
                 className={`py-2 px-1 border-b-2 font-medium text-sm transition-colors ${
                   activeQuestion === index + 1
-                    ? 'border-hackerrank-green text-hackerrank-green'
-                    : 'border-transparent text-hackerrank-textSecondary hover:text-hackerrank-text hover:border-hackerrank-border'
+                    ? 'border-meta-blue text-meta-blue'
+                    : 'border-transparent text-meta-textSecondary hover:text-meta-text hover:border-meta-border'
                 }`}
               >
                 <div className="flex items-center space-x-2">
                   <span>{index + 1}. {question?.title}</span>
                   {attempt[`question${index + 1}_code` as keyof Attempt] && (
-                    <div className="w-2 h-2 bg-hackerrank-green rounded-full"></div>
+                    <div className="w-2 h-2 bg-meta-blue rounded-full"></div>
                   )}
                 </div>
               </button>
@@ -202,12 +202,12 @@ export const AttemptReview: React.FC = () => {
         {/* Problem Description */}
         <div>
           <div className="card">
-            <h2 className="text-lg font-semibold text-hackerrank-text mb-4">Problem Description</h2>
+            <h2 className="text-lg font-semibold text-meta-text mb-4">Problem Description</h2>
             
             {currentQuestion && (
               <div className="problem-description">
                 <div className="flex items-center space-x-3 mb-4">
-                  <h3 className="text-lg font-semibold text-hackerrank-text">
+                  <h3 className="text-lg font-semibold text-meta-text">
                     {currentQuestion.title}
                   </h3>
                   <span className={`badge ${difficultyColors[currentQuestion.difficulty]} border`}>
@@ -215,11 +215,11 @@ export const AttemptReview: React.FC = () => {
                   </span>
                 </div>
                 
-                <div className="prose prose-sm max-w-none mb-4 text-hackerrank-textSecondary">
+                <div className="prose prose-sm max-w-none mb-4 text-meta-textSecondary">
                   <p>{currentQuestion.description}</p>
                 </div>
                 
-                <div className="pt-4 border-t border-hackerrank-border text-sm text-hackerrank-textSecondary">
+                <div className="pt-4 border-t border-meta-border text-sm text-meta-textSecondary">
                   <div className="flex items-center justify-between">
                     <span>Category: {currentQuestion.category}</span>
                     <span>Problem #{currentQuestion.neetcode_number}</span>
@@ -233,9 +233,9 @@ export const AttemptReview: React.FC = () => {
         {/* Code Submission */}
         <div>
           <div className="card p-0 overflow-hidden">
-            <div className="px-6 py-4 border-b border-hackerrank-border bg-hackerrank-darker">
+            <div className="px-6 py-4 border-b border-meta-border bg-meta-darker">
               <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-hackerrank-text">Your Submission</h2>
+                <h2 className="text-lg font-semibold text-meta-text">Your Submission</h2>
                 {currentCode.language && (
                   <span className="badge badge-info">
                     {currentCode.language}
@@ -255,8 +255,8 @@ export const AttemptReview: React.FC = () => {
                 />
               ) : (
                 <div className="p-12 text-center">
-                  <div className="text-hackerrank-textSecondary mb-2">No code submitted</div>
-                  <p className="text-sm text-hackerrank-textSecondary">
+                  <div className="text-meta-textSecondary mb-2">No code submitted</div>
+                  <p className="text-sm text-meta-textSecondary">
                     This problem was not attempted during the contest.
                   </p>
                 </div>

--- a/frontend/src/pages/ContestAttempt.tsx
+++ b/frontend/src/pages/ContestAttempt.tsx
@@ -154,8 +154,8 @@ export const ContestAttempt: React.FC = () => {
     return (
       <div className="h-screen flex items-center justify-center bg-gradient-bg">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-hackerrank-green mx-auto mb-4"></div>
-          <p className="text-hackerrank-textSecondary text-lg font-medium">Loading contest...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-meta-blue mx-auto mb-4"></div>
+          <p className="text-meta-textSecondary text-lg font-medium">Loading contest...</p>
         </div>
       </div>
     )
@@ -168,28 +168,28 @@ export const ContestAttempt: React.FC = () => {
   return (
     <div className="h-screen flex flex-col bg-gradient-bg">
       {/* Header */}
-      <div className="flex-shrink-0 border-b border-hackerrank-border bg-hackerrank-darker/80 backdrop-blur-md px-6 py-4">
+      <div className="flex-shrink-0 border-b border-meta-border bg-meta-darker/80 backdrop-blur-md px-6 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-4">
             <button
               onClick={() => navigate(`/contest/${id}`)}
-              className="btn btn-secondary btn-sm shadow-hackerrank"
+              className="btn btn-secondary btn-sm shadow-meta"
             >
               Back
             </button>
             
             <div>
-              <h1 className="text-xl font-bold text-hackerrank-text">
+              <h1 className="text-xl font-bold text-meta-text">
                 {attempt.contest?.name}
               </h1>
-              <p className="text-sm text-hackerrank-textSecondary font-medium">
+              <p className="text-sm text-meta-textSecondary font-medium">
                 Problem {activeQuestion} of 3
               </p>
             </div>
             
             {saving && (
-              <div className="flex items-center space-x-2 text-sm text-hackerrank-textSecondary">
-                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-hackerrank-green"></div>
+              <div className="flex items-center space-x-2 text-sm text-meta-textSecondary">
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-meta-blue"></div>
                 <span className="font-medium">Saving...</span>
               </div>
             )}
@@ -198,14 +198,14 @@ export const ContestAttempt: React.FC = () => {
           <div className="flex items-center space-x-3">
             <button
               onClick={finishContest}
-              className="btn btn-success btn-sm shadow-hackerrank"
+              className="btn btn-success btn-sm shadow-meta"
             >
               Submit
             </button>
             
             <button
               onClick={abandonContest}
-              className="btn btn-danger btn-sm shadow-hackerrank"
+              className="btn btn-danger btn-sm shadow-meta"
             >
               Exit
             </button>
@@ -214,31 +214,31 @@ export const ContestAttempt: React.FC = () => {
       </div>
 
       {/* Timer */}
-      <div className="flex-shrink-0 px-6 py-4 border-b border-hackerrank-border bg-hackerrank-light/50 backdrop-blur-sm">
+      <div className="flex-shrink-0 px-6 py-4 border-b border-meta-border bg-meta-light/50 backdrop-blur-sm">
         <Timer onTimeUp={handleTimeUp} />
       </div>
 
       {/* Main Content */}
       <div className="flex-1 flex overflow-hidden">
         {/* Left Panel - Problem Description */}
-        <div className="w-1/2 flex flex-col border-r border-hackerrank-border">
+        <div className="w-1/2 flex flex-col border-r border-meta-border">
           {/* Problem Navigation */}
-          <div className="flex-shrink-0 border-b border-hackerrank-border bg-hackerrank-darker/50 backdrop-blur-sm">
+          <div className="flex-shrink-0 border-b border-meta-border bg-meta-darker/50 backdrop-blur-sm">
             <div className="flex">
               {questions.map((question, index) => (
                 <button
                   key={question?.id}
                   onClick={() => setActiveQuestion(index + 1)}
-                  className={`flex-1 px-4 py-3 text-sm font-semibold border-r border-hackerrank-border last:border-r-0 transition-all duration-200 ${
+                  className={`flex-1 px-4 py-3 text-sm font-semibold border-r border-meta-border last:border-r-0 transition-all duration-200 ${
                     activeQuestion === index + 1
-                      ? 'bg-hackerrank-green/10 text-hackerrank-green border-b-2 border-hackerrank-green'
-                      : 'text-hackerrank-textSecondary hover:bg-hackerrank-light hover:text-hackerrank-text'
+                      ? 'bg-meta-blue/10 text-meta-blue border-b-2 border-meta-blue'
+                      : 'text-meta-textSecondary hover:bg-meta-light hover:text-meta-text'
                   }`}
                 >
                   <div className="flex items-center justify-center space-x-2">
                     <span>{index + 1}. {question?.title}</span>
                     {codes[index + 1 as keyof typeof codes].code.trim() && (
-                      <div className="w-2 h-2 bg-hackerrank-green rounded-full animate-pulse"></div>
+                      <div className="w-2 h-2 bg-meta-blue rounded-full animate-pulse"></div>
                     )}
                   </div>
                 </button>
@@ -247,11 +247,11 @@ export const ContestAttempt: React.FC = () => {
           </div>
 
           {/* Problem Content */}
-          <div className="flex-1 overflow-y-auto p-6 bg-hackerrank-light/50 backdrop-blur-sm">
+          <div className="flex-1 overflow-y-auto p-6 bg-meta-light/50 backdrop-blur-sm">
             {questions[activeQuestion - 1] && (
               <div className="problem-description">
                 <div className="flex items-center space-x-3 mb-6">
-                  <h2 className="text-2xl font-bold text-hackerrank-text">
+                  <h2 className="text-2xl font-bold text-meta-text">
                     {questions[activeQuestion - 1]?.title}
                   </h2>
                   <span className={`badge ${difficultyColors[questions[activeQuestion - 1]?.difficulty!]} border`}>
@@ -259,11 +259,11 @@ export const ContestAttempt: React.FC = () => {
                   </span>
                 </div>
                 
-                <div className="prose prose-sm max-w-none text-hackerrank-textSecondary leading-relaxed">
+                <div className="prose prose-sm max-w-none text-meta-textSecondary leading-relaxed">
                   <p className="text-base">{questions[activeQuestion - 1]?.description}</p>
                 </div>
                 
-                <div className="mt-8 pt-4 border-t border-hackerrank-border text-sm text-hackerrank-textSecondary">
+                <div className="mt-8 pt-4 border-t border-meta-border text-sm text-meta-textSecondary">
                   <div className="flex items-center justify-between">
                     <span className="font-medium">Category: {questions[activeQuestion - 1]?.category}</span>
                     <span className="font-mono">Problem #{questions[activeQuestion - 1]?.neetcode_number}</span>
@@ -277,9 +277,9 @@ export const ContestAttempt: React.FC = () => {
         {/* Right Panel - Code Editor */}
         <div className="w-1/2 flex flex-col">
           {/* Editor Header */}
-          <div className="flex-shrink-0 border-b border-hackerrank-border bg-hackerrank-darker/50 backdrop-blur-sm px-6 py-4">
+          <div className="flex-shrink-0 border-b border-meta-border bg-meta-darker/50 backdrop-blur-sm px-6 py-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-hackerrank-text">Code</h3>
+              <h3 className="text-sm font-semibold text-meta-text">Code</h3>
               <LanguageSelector
                 selectedLanguage={currentCode.language}
                 onChange={handleLanguageChange}

--- a/frontend/src/pages/ContestDetails.tsx
+++ b/frontend/src/pages/ContestDetails.tsx
@@ -64,10 +64,10 @@ export const ContestDetails: React.FC = () => {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="animate-pulse">
-          <div className="h-8 bg-hackerrank-light rounded-xl w-1/3 mb-6"></div>
+          <div className="h-8 bg-meta-light rounded-xl w-1/3 mb-6"></div>
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {[...Array(3)].map((_, i) => (
-              <div key={i} className="h-64 bg-hackerrank-light rounded-xl"></div>
+              <div key={i} className="h-64 bg-meta-light rounded-xl"></div>
             ))}
           </div>
         </div>
@@ -79,7 +79,7 @@ export const ContestDetails: React.FC = () => {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-hackerrank-text mb-4">Contest not found</h1>
+          <h1 className="text-2xl font-bold text-meta-text mb-4">Contest not found</h1>
           <Link to="/" className="btn btn-primary">Back to Problems</Link>
         </div>
       </div>
@@ -94,16 +94,16 @@ export const ContestDetails: React.FC = () => {
       <nav className="flex mb-6" aria-label="Breadcrumb">
         <ol className="flex items-center space-x-4">
           <li>
-            <Link to="/" className="text-hackerrank-textSecondary hover:text-hackerrank-text transition-colors">
+            <Link to="/" className="text-meta-textSecondary hover:text-meta-text transition-colors">
               Problems
             </Link>
           </li>
           <li>
             <div className="flex items-center">
-              <svg className="flex-shrink-0 h-5 w-5 text-hackerrank-border" fill="currentColor" viewBox="0 0 20 20">
+              <svg className="flex-shrink-0 h-5 w-5 text-meta-border" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
               </svg>
-              <span className="ml-4 text-sm font-semibold text-hackerrank-text">{contest.name}</span>
+              <span className="ml-4 text-sm font-semibold text-meta-text">{contest.name}</span>
             </div>
           </li>
         </ol>
@@ -113,10 +113,10 @@ export const ContestDetails: React.FC = () => {
       <div className="mb-8">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-4xl font-bold text-hackerrank-text mb-3 bg-gradient-to-r from-hackerrank-text to-hackerrank-textSecondary bg-clip-text text-transparent">
+            <h1 className="text-4xl font-bold text-meta-text mb-3 bg-gradient-to-r from-meta-text to-meta-textSecondary bg-clip-text text-transparent">
               {contest.name}
             </h1>
-            <p className="text-hackerrank-textSecondary text-lg">
+            <p className="text-meta-textSecondary text-lg">
               Solve 3 problems in 1 hour • Choose your programming language
             </p>
           </div>
@@ -124,7 +124,7 @@ export const ContestDetails: React.FC = () => {
             <button
               onClick={handleStartContest}
               disabled={startingContest}
-              className="btn btn-primary btn-lg shadow-hackerrank-lg"
+              className="btn btn-primary btn-lg shadow-meta-lg"
             >
               {startingContest ? 'Starting...' : 'Start Contest'}
             </button>
@@ -134,16 +134,16 @@ export const ContestDetails: React.FC = () => {
 
       {/* Problems */}
       <div className="mb-8">
-        <h2 className="text-2xl font-bold text-hackerrank-text mb-6">Problems</h2>
+        <h2 className="text-2xl font-bold text-meta-text mb-6">Problems</h2>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {questions.map((question, index) => (
-            <div key={question?.id} className="card hackerrank-card-hover gradient-card">
+            <div key={question?.id} className="card meta-card-hover gradient-card">
               <div className="flex items-start justify-between mb-4">
                 <div className="flex items-center space-x-3">
-                  <span className="text-lg font-bold text-hackerrank-textSecondary">
+                  <span className="text-lg font-bold text-meta-textSecondary">
                     {index + 1}.
                   </span>
-                  <h3 className="font-bold text-hackerrank-text text-lg">{question?.title}</h3>
+                  <h3 className="font-bold text-meta-text text-lg">{question?.title}</h3>
                 </div>
                 {question && (
                   <span className={`badge ${difficultyColors[question.difficulty]} border`}>
@@ -152,11 +152,11 @@ export const ContestDetails: React.FC = () => {
                 )}
               </div>
               
-              <p className="text-sm text-hackerrank-textSecondary mb-4 line-clamp-3">
+              <p className="text-sm text-meta-textSecondary mb-4 line-clamp-3">
                 {question?.description}
               </p>
               
-              <div className="flex items-center justify-between text-xs text-hackerrank-textSecondary">
+              <div className="flex items-center justify-between text-xs text-meta-textSecondary">
                 <span className="font-medium">{question?.category}</span>
                 <span className="font-mono">#{question?.neetcode_number}</span>
               </div>
@@ -168,20 +168,20 @@ export const ContestDetails: React.FC = () => {
       {/* Submissions History */}
       {attempts.length > 0 && (
         <div>
-          <h2 className="text-2xl font-bold text-hackerrank-text mb-6">Your Submissions</h2>
+          <h2 className="text-2xl font-bold text-meta-text mb-6">Your Submissions</h2>
           <div className="card p-0 overflow-hidden gradient-card">
-            <div className="px-6 py-4 bg-hackerrank-darker/50 border-b border-hackerrank-border">
+            <div className="px-6 py-4 bg-meta-darker/50 border-b border-meta-border">
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-semibold text-hackerrank-text">Submission History</h3>
-                <div className="text-sm text-hackerrank-textSecondary">
+                <h3 className="text-sm font-semibold text-meta-text">Submission History</h3>
+                <div className="text-sm text-meta-textSecondary">
                   {attempts.length} submission{attempts.length !== 1 ? 's' : ''}
                 </div>
               </div>
             </div>
             
-            <div className="divide-y divide-hackerrank-border">
+            <div className="divide-y divide-meta-border">
               {attempts.map((attempt) => (
-                <div key={attempt.id} className="px-6 py-4 hover:bg-hackerrank-darker/30 transition-all duration-200">
+                <div key={attempt.id} className="px-6 py-4 hover:bg-meta-darker/30 transition-all duration-200">
                   <div className="flex items-center justify-between">
                     <div className="flex-1">
                       <div className="flex items-center space-x-4 mb-3">
@@ -189,12 +189,12 @@ export const ContestDetails: React.FC = () => {
                           {getStatusText(attempt.status)}
                         </span>
                         
-                        <span className="text-sm text-hackerrank-textSecondary font-medium">
+                        <span className="text-sm text-meta-textSecondary font-medium">
                           {new Date(attempt.started_at).toLocaleString()}
                         </span>
                         
                         {attempt.completed_at && (
-                          <span className="text-sm text-hackerrank-textSecondary font-medium">
+                          <span className="text-sm text-meta-textSecondary font-medium">
                             Duration: {formatTime(attempt.duration_seconds || 0)}
                           </span>
                         )}
@@ -202,20 +202,20 @@ export const ContestDetails: React.FC = () => {
                       
                       <div className="grid grid-cols-3 gap-4 text-sm">
                         <div>
-                          <span className="text-hackerrank-textSecondary">Problem 1:</span>
-                          <span className="ml-2 font-semibold text-hackerrank-text">
+                          <span className="text-meta-textSecondary">Problem 1:</span>
+                          <span className="ml-2 font-semibold text-meta-text">
                             {attempt.question1_language || 'Not attempted'}
                           </span>
                         </div>
                         <div>
-                          <span className="text-hackerrank-textSecondary">Problem 2:</span>
-                          <span className="ml-2 font-semibold text-hackerrank-text">
+                          <span className="text-meta-textSecondary">Problem 2:</span>
+                          <span className="ml-2 font-semibold text-meta-text">
                             {attempt.question2_language || 'Not attempted'}
                           </span>
                         </div>
                         <div>
-                          <span className="text-hackerrank-textSecondary">Problem 3:</span>
-                          <span className="ml-2 font-semibold text-hackerrank-text">
+                          <span className="text-meta-textSecondary">Problem 3:</span>
+                          <span className="ml-2 font-semibold text-meta-text">
                             {attempt.question3_language || 'Not attempted'}
                           </span>
                         </div>
@@ -255,31 +255,31 @@ export const ContestDetails: React.FC = () => {
       )}
 
       {/* Contest Info */}
-      <div className="mt-8 card bg-hackerrank-success/10 border-hackerrank-success/20 gradient-card">
-        <h3 className="text-lg font-semibold text-hackerrank-success mb-4">Contest Rules</h3>
-        <ul className="text-hackerrank-textSecondary space-y-2">
+      <div className="mt-8 card bg-meta-success/10 border-meta-success/20 gradient-card">
+        <h3 className="text-lg font-semibold text-meta-success mb-4">Contest Rules</h3>
+        <ul className="text-meta-textSecondary space-y-2">
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>You have 1 hour to complete all 3 problems</span>
           </li>
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>Choose from Python, Java, C++, or JavaScript</span>
           </li>
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>Your code is automatically saved as you type</span>
           </li>
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>You'll receive notifications at 30 minutes and 5 minutes remaining</span>
           </li>
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>You can finish early or let the timer expire</span>
           </li>
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>Multiple attempts are allowed</span>
           </li>
         </ul>

--- a/frontend/src/pages/ContestList.tsx
+++ b/frontend/src/pages/ContestList.tsx
@@ -39,10 +39,10 @@ export const ContestList: React.FC = () => {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="animate-pulse">
-          <div className="h-8 bg-hackerrank-light rounded-xl w-1/4 mb-6"></div>
+          <div className="h-8 bg-meta-light rounded-xl w-1/4 mb-6"></div>
           <div className="grid grid-cols-1 gap-4">
             {[...Array(5)].map((_, i) => (
-              <div key={i} className="h-16 bg-hackerrank-light rounded-xl"></div>
+              <div key={i} className="h-16 bg-meta-light rounded-xl"></div>
             ))}
           </div>
         </div>
@@ -54,62 +54,62 @@ export const ContestList: React.FC = () => {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-4xl font-bold text-hackerrank-text mb-3 bg-gradient-to-r from-hackerrank-text to-hackerrank-textSecondary bg-clip-text text-transparent">
+        <h1 className="text-4xl font-bold text-meta-text mb-3 bg-gradient-to-r from-meta-text to-meta-textSecondary bg-clip-text text-transparent">
           Problems
         </h1>
-        <p className="text-hackerrank-textSecondary text-lg">
+        <p className="text-meta-textSecondary text-lg">
           Practice coding with timed contests. Each contest contains 3 carefully selected problems.
         </p>
       </div>
 
       {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-        <div className="card hackerrank-card-hover gradient-card">
+        <div className="card meta-card-hover gradient-card">
           <div className="flex items-center">
             <div className="flex-1">
-              <p className="text-sm font-medium text-hackerrank-textSecondary">Total Problems</p>
-              <p className="text-3xl font-bold text-hackerrank-text">{stats.total * 3}</p>
+              <p className="text-sm font-medium text-meta-textSecondary">Total Problems</p>
+              <p className="text-3xl font-bold text-meta-text">{stats.total * 3}</p>
             </div>
-            <div className="w-12 h-12 bg-hackerrank-success/20 rounded-xl flex items-center justify-center">
-              <div className="w-6 h-6 bg-hackerrank-success rounded-lg"></div>
+            <div className="w-12 h-12 bg-meta-success/20 rounded-xl flex items-center justify-center">
+              <div className="w-6 h-6 bg-meta-success rounded-lg"></div>
             </div>
           </div>
         </div>
 
-        <div className="card hackerrank-card-hover gradient-card">
+        <div className="card meta-card-hover gradient-card">
           <div className="flex items-center">
             <div className="flex-1">
-              <p className="text-sm font-medium text-hackerrank-textSecondary">Attempted</p>
-              <p className="text-3xl font-bold text-hackerrank-text">{stats.attempted}</p>
+              <p className="text-sm font-medium text-meta-textSecondary">Attempted</p>
+              <p className="text-3xl font-bold text-meta-text">{stats.attempted}</p>
             </div>
-            <div className="w-12 h-12 bg-hackerrank-warning/20 rounded-xl flex items-center justify-center">
-              <div className="w-6 h-6 bg-hackerrank-warning rounded-lg"></div>
+            <div className="w-12 h-12 bg-meta-warning/20 rounded-xl flex items-center justify-center">
+              <div className="w-6 h-6 bg-meta-warning rounded-lg"></div>
             </div>
           </div>
         </div>
 
-        <div className="card hackerrank-card-hover gradient-card">
+        <div className="card meta-card-hover gradient-card">
           <div className="flex items-center">
             <div className="flex-1">
-              <p className="text-sm font-medium text-hackerrank-textSecondary">Solved</p>
-              <p className="text-3xl font-bold text-hackerrank-text">{stats.completed}</p>
+              <p className="text-sm font-medium text-meta-textSecondary">Solved</p>
+              <p className="text-3xl font-bold text-meta-text">{stats.completed}</p>
             </div>
-            <div className="w-12 h-12 bg-hackerrank-success/20 rounded-xl flex items-center justify-center">
-              <div className="w-6 h-6 bg-hackerrank-success rounded-lg"></div>
+            <div className="w-12 h-12 bg-meta-success/20 rounded-xl flex items-center justify-center">
+              <div className="w-6 h-6 bg-meta-success rounded-lg"></div>
             </div>
           </div>
         </div>
       </div>
 
       {/* Filter Tabs */}
-      <div className="border-b border-hackerrank-border mb-6">
+      <div className="border-b border-meta-border mb-6">
         <nav className="-mb-px flex space-x-8">
           <button
             onClick={() => setFilter('all')}
             className={`py-3 px-1 border-b-2 font-semibold text-sm transition-all duration-200 ${
               filter === 'all'
-                ? 'border-hackerrank-green text-hackerrank-green'
-                : 'border-transparent text-hackerrank-textSecondary hover:text-hackerrank-text hover:border-hackerrank-border'
+                ? 'border-meta-blue text-meta-blue'
+                : 'border-transparent text-meta-textSecondary hover:text-meta-text hover:border-meta-border'
             }`}
           >
             All ({contests.length})
@@ -118,8 +118,8 @@ export const ContestList: React.FC = () => {
             onClick={() => setFilter('not-attempted')}
             className={`py-3 px-1 border-b-2 font-semibold text-sm transition-all duration-200 ${
               filter === 'not-attempted'
-                ? 'border-hackerrank-green text-hackerrank-green'
-                : 'border-transparent text-hackerrank-textSecondary hover:text-hackerrank-text hover:border-hackerrank-border'
+                ? 'border-meta-blue text-meta-blue'
+                : 'border-transparent text-meta-textSecondary hover:text-meta-text hover:border-meta-border'
             }`}
           >
             Todo ({contests.length - stats.attempted})
@@ -128,8 +128,8 @@ export const ContestList: React.FC = () => {
             onClick={() => setFilter('attempted')}
             className={`py-3 px-1 border-b-2 font-semibold text-sm transition-all duration-200 ${
               filter === 'attempted'
-                ? 'border-hackerrank-green text-hackerrank-green'
-                : 'border-transparent text-hackerrank-textSecondary hover:text-hackerrank-text hover:border-hackerrank-border'
+                ? 'border-meta-blue text-meta-blue'
+                : 'border-transparent text-meta-textSecondary hover:text-meta-text hover:border-meta-border'
             }`}
           >
             Attempted ({stats.attempted})
@@ -139,20 +139,20 @@ export const ContestList: React.FC = () => {
 
       {/* Contest List */}
       <div className="card p-0 overflow-hidden gradient-card">
-        <div className="px-6 py-4 bg-hackerrank-darker/50 border-b border-hackerrank-border">
+        <div className="px-6 py-4 bg-meta-darker/50 border-b border-meta-border">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-hackerrank-text">Contests</h3>
-            <div className="text-sm text-hackerrank-textSecondary">
+            <h3 className="text-sm font-semibold text-meta-text">Contests</h3>
+            <div className="text-sm text-meta-textSecondary">
               {filteredContests.length} contest{filteredContests.length !== 1 ? 's' : ''}
             </div>
           </div>
         </div>
 
-        <div className="divide-y divide-hackerrank-border">
+        <div className="divide-y divide-meta-border">
           {filteredContests.length === 0 ? (
             <div className="px-6 py-12 text-center">
-              <div className="text-hackerrank-textSecondary mb-2 text-lg font-medium">No contests found</div>
-              <p className="text-sm text-hackerrank-textSecondary">
+              <div className="text-meta-textSecondary mb-2 text-lg font-medium">No contests found</div>
+              <p className="text-sm text-meta-textSecondary">
                 {filter === 'attempted' 
                   ? "You haven't attempted any contests yet."
                   : filter === 'not-attempted'
@@ -162,7 +162,7 @@ export const ContestList: React.FC = () => {
             </div>
           ) : (
             filteredContests.map((contest) => (
-              <div key={contest.id} className="px-6 py-4 hover:bg-hackerrank-darker/50 transition-all duration-200">
+              <div key={contest.id} className="px-6 py-4 hover:bg-meta-darker/50 transition-all duration-200">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-4">
                     <div className="flex-shrink-0">
@@ -179,7 +179,7 @@ export const ContestList: React.FC = () => {
                       <div className="flex items-center space-x-3">
                         <Link 
                           to={`/contest/${contest.id}`}
-                          className="text-hackerrank-green hover:text-hackerrank-greenLight font-semibold text-lg transition-colors"
+                          className="text-meta-blue hover:text-meta-blueLight font-semibold text-lg transition-colors"
                         >
                           {contest.name}
                         </Link>
@@ -190,14 +190,14 @@ export const ContestList: React.FC = () => {
                           <span className="badge badge-warning">Attempted</span>
                         )}
                       </div>
-                      <div className="mt-1 text-sm text-hackerrank-textSecondary">
+                      <div className="mt-1 text-sm text-meta-textSecondary">
                         3 problems • 1 hour time limit • Multiple languages
                       </div>
                     </div>
                   </div>
 
                   <div className="flex items-center space-x-3">
-                    <div className="text-sm text-hackerrank-textSecondary">
+                    <div className="text-sm text-meta-textSecondary">
                       {contest.has_attempts ? 'Attempted' : 'New'}
                     </div>
                     <Link
@@ -215,27 +215,27 @@ export const ContestList: React.FC = () => {
       </div>
 
       {/* Help Section */}
-      <div className="mt-8 card bg-hackerrank-success/10 border-hackerrank-success/20 gradient-card">
-        <h3 className="text-lg font-semibold text-hackerrank-success mb-3">How it works</h3>
-        <ul className="text-hackerrank-textSecondary space-y-2 text-sm">
+      <div className="mt-8 card bg-meta-success/10 border-meta-success/20 gradient-card">
+        <h3 className="text-lg font-semibold text-meta-success mb-3">How it works</h3>
+        <ul className="text-meta-textSecondary space-y-2 text-sm">
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>Each contest contains 3 carefully selected problems</span>
           </li>
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>You have 1 hour to solve all problems</span>
           </li>
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>Choose from Python, Java, C++, or JavaScript</span>
           </li>
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>Your progress is automatically saved</span>
           </li>
           <li className="flex items-center space-x-2">
-            <div className="w-1.5 h-1.5 bg-hackerrank-success rounded-full"></div>
+            <div className="w-1.5 h-1.5 bg-meta-success rounded-full"></div>
             <span>Get notifications at 30 minutes and 5 minutes remaining</span>
           </li>
         </ul>

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -224,10 +224,10 @@ export const ContestPage: React.FC<ContestPageProps> = ({ contestId, attemptId }
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-meta-dark flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading contest...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-meta-blue mx-auto mb-4"></div>
+          <p className="text-meta-textSecondary">Loading contest...</p>
         </div>
       </div>
     )
@@ -235,13 +235,13 @@ export const ContestPage: React.FC<ContestPageProps> = ({ contestId, attemptId }
 
   if (error || !contest || !templates) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-meta-dark flex items-center justify-center">
         <div className="text-center">
-          <div className="text-red-600 text-xl mb-4">❌ Error</div>
-          <p className="text-gray-600">{error || 'Failed to load contest'}</p>
+          <div className="text-meta-error text-xl mb-4">❌ Error</div>
+          <p className="text-meta-textSecondary">{error || 'Failed to load contest'}</p>
           <button 
             onClick={() => window.location.href = '/'} 
-            className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            className="mt-4 px-4 py-2 bg-meta-blue text-meta-dark rounded hover:bg-meta-blueDark"
           >
             Back to Contests
           </button>
@@ -254,43 +254,43 @@ export const ContestPage: React.FC<ContestPageProps> = ({ contestId, attemptId }
   const currentCode = codes[activeQuestion as keyof typeof codes]
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-meta-dark">
       {/* Header */}
-      <div className="bg-white shadow-sm border-b">
+      <div className="bg-meta-light shadow-meta border-b border-meta-border">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
               <button
                 onClick={() => window.location.href = '/'}
-                className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500"
+                className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-meta-border text-meta-text hover:bg-meta-lighter focus:ring-meta-blue"
               >
                 ← Back
               </button>
               
               <div>
-                <h1 className="text-2xl font-bold text-gray-900">{contest.name}</h1>
-                <p className="text-gray-600">Question {activeQuestion} of 3</p>
+                <h1 className="text-2xl font-bold text-meta-text">{contest.name}</h1>
+                <p className="text-meta-textSecondary">Question {activeQuestion} of 3</p>
               </div>
             </div>
             
             <div className="flex space-x-3">
               <button
                 onClick={() => saveAttempt()}
-                className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500"
+                className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-meta-border text-meta-text hover:bg-meta-lighter focus:ring-meta-blue"
               >
                 💾 Save
               </button>
               
               <button
                 onClick={finishContest}
-                className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-green-600 text-white hover:bg-green-700 focus:ring-green-500"
+                className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-meta-success text-meta-dark hover:bg-meta-success/90 focus:ring-meta-success"
               >
                 ✅ Finish
               </button>
               
               <button
                 onClick={abandonContest}
-                className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-red-600 text-white hover:bg-red-700 focus:ring-red-500"
+                className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-meta-error text-white hover:bg-meta-error/90 focus:ring-meta-error"
               >
                 ❌ Abandon
               </button>
@@ -312,13 +312,13 @@ export const ContestPage: React.FC<ContestPageProps> = ({ contestId, attemptId }
                 onClick={() => setActiveQuestion(num)}
                 className={`px-4 py-2 rounded-lg font-medium transition-all ${
                   activeQuestion === num
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-white text-gray-600 border border-gray-300 hover:bg-gray-50'
+                    ? 'bg-meta-blue text-meta-dark'
+                    : 'bg-meta-light text-meta-text border border-meta-border hover:bg-meta-lighter'
                 }`}
               >
                 Q{num}
                 {codes[num as keyof typeof codes].code.trim() && (
-                  <span className="ml-2 w-2 h-2 bg-green-500 rounded-full inline-block" />
+                  <span className="ml-2 w-2 h-2 bg-meta-success rounded-full inline-block" />
                 )}
               </button>
             ))}
@@ -328,7 +328,7 @@ export const ContestPage: React.FC<ContestPageProps> = ({ contestId, attemptId }
             <button
               onClick={() => setActiveQuestion(Math.max(1, activeQuestion - 1))}
               disabled={activeQuestion === 1}
-              className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-meta-border text-meta-text hover:bg-meta-lighter focus:ring-meta-blue disabled:opacity-50 disabled:cursor-not-allowed"
             >
               ← Previous
             </button>
@@ -336,7 +336,7 @@ export const ContestPage: React.FC<ContestPageProps> = ({ contestId, attemptId }
             <button
               onClick={() => setActiveQuestion(Math.min(3, activeQuestion + 1))}
               disabled={activeQuestion === 3}
-              className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 bg-meta-border text-meta-text hover:bg-meta-lighter focus:ring-meta-blue disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Next →
             </button>
@@ -364,7 +364,7 @@ export const ContestPage: React.FC<ContestPageProps> = ({ contestId, attemptId }
           {/* Code Panel */}
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-gray-900">Code Editor</h3>
+              <h3 className="text-lg font-semibold text-meta-text">Code Editor</h3>
               <LanguageSelector
                 selectedLanguage={currentCode.language}
                 onChange={(language) => handleLanguageChange(activeQuestion, language)}

--- a/frontend/src/utils/language.ts
+++ b/frontend/src/utils/language.ts
@@ -32,15 +32,15 @@ export const getLanguageConfig = (language: Language) => {
 };
 
 export const difficultyColors = {
-  Easy: 'text-hackerrank-green bg-hackerrank-green/10 border-hackerrank-green/20',
-  Medium: 'text-yellow-400 bg-yellow-400/10 border-yellow-400/20',
-  Hard: 'text-red-400 bg-red-400/10 border-red-400/20',
+  Easy: 'text-meta-success bg-meta-success/10 border-meta-success/20',
+  Medium: 'text-meta-warning bg-meta-warning/10 border-meta-warning/20',
+  Hard: 'text-meta-error bg-meta-error/10 border-meta-error/20',
 } as const;
 
 export const statusColors = {
-  in_progress: 'text-hackerrank-green bg-hackerrank-green/10 border-hackerrank-green/20',
-  completed: 'text-hackerrank-green bg-hackerrank-green text-hackerrank-dark font-semibold',
-  abandoned: 'text-hackerrank-textSecondary bg-hackerrank-light border-hackerrank-border',
+  in_progress: 'text-meta-blue bg-meta-blue/10 border-meta-blue/20',
+  completed: 'text-meta-success bg-meta-success text-meta-dark font-semibold',
+  abandoned: 'text-meta-textSecondary bg-meta-light border-meta-border',
 } as const;
 
 export const getStatusText = (status: AttemptStatus): string => {

--- a/frontend/src/utils/timer.ts
+++ b/frontend/src/utils/timer.ts
@@ -15,12 +15,12 @@ export const getTimerColor = (timeLeft: number): string => {
   const percentage = timeLeft / totalTime;
   
   if (percentage <= 0.083) { // 5 minutes or less (5/60 = 0.083)
-    return 'text-red-500 timer-danger';
+    return 'text-meta-error timer-danger';
   } else if (percentage <= 0.5) { // 30 minutes or less
-    return 'text-yellow-500 timer-warning';
+    return 'text-meta-warning timer-warning';
   }
   
-  return 'text-hackerrank-green';
+  return 'text-meta-blue';
 };
 
 export const shouldShowNotification = (

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,51 +8,51 @@ export default {
     extend: {
       colors: {
         primary: {
-          50: '#f0fdf4',
-          100: '#dcfce7',
-          200: '#bbf7d0',
-          300: '#86efac',
-          400: '#4ade80',
-          500: '#22c55e',
-          600: '#16a34a',
-          700: '#15803d',
-          800: '#166534',
-          900: '#14532d',
+          50: '#f0f9ff',
+          100: '#e0f2fe',
+          200: '#bae6fd',
+          300: '#7dd3fc',
+          400: '#38bdf8',
+          500: '#0ea5e9',
+          600: '#0284c7',
+          700: '#0369a1',
+          800: '#075985',
+          900: '#0c4a6e',
         },
-        hackerrank: {
-          // Main brand colors - HackerRank green
-          green: '#00ea64',
-          greenDark: '#00c853',
-          greenLight: '#00ff6b',
+        meta: {
+          // Main brand colors - Meta blue
+          blue: '#0ea5e9',
+          blueDark: '#0284c7',
+          blueLight: '#38bdf8',
           
           // Background colors - Clean, modern grays
-          dark: '#0f1419',
-          darker: '#0a0e13',
-          light: '#1a1f2e',
-          lighter: '#2a2f3e',
+          dark: '#0f172a',
+          darker: '#020617',
+          light: '#1e293b',
+          lighter: '#334155',
           
           // Text colors - Better contrast
-          text: '#ffffff',
-          textSecondary: '#a0aec0',
-          textMuted: '#718096',
+          text: '#f8fafc',
+          textSecondary: '#cbd5e1',
+          textMuted: '#94a3b8',
           
           // Border colors - Subtle and modern
-          border: '#2d3748',
-          borderLight: '#4a5568',
+          border: '#334155',
+          borderLight: '#475569',
           
           // Accent colors
-          blue: '#3182ce',
-          blueLight: '#63b3ed',
-          yellow: '#d69e2e',
-          yellowLight: '#f6e05e',
-          red: '#e53e3e',
-          redLight: '#fc8181',
+          purple: '#8b5cf6',
+          purpleLight: '#a78bfa',
+          yellow: '#f59e0b',
+          yellowLight: '#fbbf24',
+          red: '#ef4444',
+          redLight: '#f87171',
           
           // Status colors
-          success: '#00ea64',
-          warning: '#f6ad55',
-          error: '#fc8181',
-          info: '#63b3ed',
+          success: '#10b981',
+          warning: '#f59e0b',
+          error: '#ef4444',
+          info: '#3b82f6',
         }
       },
       fontFamily: {
@@ -60,8 +60,8 @@ export default {
         sans: ['Inter', 'system-ui', 'sans-serif'],
       },
       boxShadow: {
-        'hackerrank': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
-        'hackerrank-lg': '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+        'meta': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+        'meta-lg': '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
       },
       animation: {
         'pulse-slow': 'pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite',


### PR DESCRIPTION
Re-themes the application to a modern, meta/perplexity-like color scheme and removes all HackerRank branding, as requested, while maintaining the existing layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-caed4d29-b626-4ec5-93aa-902ed61a8e1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-caed4d29-b626-4ec5-93aa-902ed61a8e1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

